### PR TITLE
Fix: guard missing Immunefi reward fields

### DIFF
--- a/backend-daf/create-static-site-for-all-protocols.py
+++ b/backend-daf/create-static-site-for-all-protocols.py
@@ -82,12 +82,12 @@ if __name__ == "__main__":
 
             for reward in reward_categories[assetType]:
                 # Amount
-                if reward["maxReward"]:
+                if "maxReward" in reward and reward["maxReward"]:
                     amount = f"<${reward['maxReward']:,.0f}"
-                elif reward["fixedReward"]:
+                elif "fixedReward" in reward and reward["fixedReward"]:
                     amount = f"${reward['fixedReward']:,.0f}"
                 # Amount Backwards-Compatibility (Immunefi used to use "Payout" instead of "fixedReward" and "maxReward")
-                elif reward["payout"]:
+                elif "payout" in reward and reward["payout"]:
                     amount = reward["payout"]
                 # Severity
                 if reward["severity"] == "critical":

--- a/backend-daf/create-static-site-for-target-protocols.py
+++ b/backend-daf/create-static-site-for-target-protocols.py
@@ -82,12 +82,12 @@ if __name__ == "__main__":
 
             for reward in reward_categories[assetType]:
                 # Amount
-                if reward["maxReward"]:
+                if "maxReward" in reward and reward["maxReward"]:
                     amount = f"<${reward['maxReward']:,.0f}"
-                elif reward["fixedReward"]:
+                elif "fixedReward" in reward and reward["fixedReward"]:
                     amount = f"${reward['fixedReward']:,.0f}"
                 # Amount Backwards-Compatibility (Immunefi used to use "Payout" instead of "fixedReward" and "maxReward")
-                elif reward["payout"]:
+                elif "payout" in reward and reward["payout"]:
                     amount = reward["payout"]
                 # Severity
                 if reward["severity"] == "critical":


### PR DESCRIPTION
Fixes a crash in static site generators when Immunefi API omits `maxReward` in favor of `fixedReward` or legacy `payout` fields. We now check key existence before accessing each field.

- Affects: `backend-daf/create-static-site-for-all-protocols.py`, `backend-daf/create-static-site-for-target-protocols.py`
- Behavior: Prevents KeyError for programs that use `fixedReward` only or legacy `payout` field.