### PR TITLE
Feat: adding target protocols is now easier; README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,27 +114,22 @@ python3 -m http.server 8000
 
 ### Monitor target protocols
 
-**Step 1-** Create a list of targets at `./backend-daf/targets.json` in the following format:
-
-```json
-{
-  "targets": [
-    "layerzero",
-    "reserve"
-  ]
-}
-```
-
-> Use the ID of the bug bounty program, as seen in Immunefi's API or ibb.
-
-**Step 2-** Get an updated list of assets in scope from Immunefi.
+**Step 1-** Add a target protocol using a single command.
 
 ```bash
 # First, cd into `./backend-daf/`
 cd backend-daf
 
-./read-target-protocols-from-immunefi.sh
+./add-protocol-from-immunefi.sh layerzero
+# or another program id from Immunefi/ibb, e.g.:
+./add-protocol-from-immunefi.sh listadao
 ```
+
+This fetches the program logo, rewards, and GitHub repositories in scope and appends them to `backend-daf/target_protocols.json`.
+
+**Step 2-** (Optional) Customize repositories.
+
+You can add or remove GitHub repositories for any target directly in `backend-daf/target_protocols.json` under the `assetUrls` array of the protocol you added.
 
 **Step 3:** Scan for pull requests merged today in your target's GitHub repositories.
 

--- a/backend-daf/add-protocol-from-immunefi.sh
+++ b/backend-daf/add-protocol-from-immunefi.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+# Append a single Immunefi protocol entry to target_protocols.json
+# Usage: ./add-protocol-from-immunefi.sh <protocol_name>
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $0 <protocol_name>" >&2
+  exit 1
+fi
+
+target_name="$1"
+output_json="target_protocols.json"
+
+echo "Adding protocol: $target_name"
+
+# Ensure output file exists and is a valid JSON array
+if [[ ! -f "$output_json" || ! -s "$output_json" ]]; then
+  echo "[]" >"$output_json"
+fi
+
+# Validate existing JSON structure
+if ! jq empty "$output_json" >/dev/null 2>&1; then
+  echo "Error: $output_json is not valid JSON." >&2
+  exit 1
+fi
+
+# Check if protocol already exists
+if jq -e --arg name "$target_name" 'map(.protocol) | index($name) | . != null' "$output_json" >/dev/null; then
+  echo "Protocol '$target_name' already present in $output_json. Skipping." >&2
+  exit 0
+fi
+
+# Get all available protocols from ibb and verify the requested one exists
+all_protocols=$(ibb | jq -r '.[]')
+if ! echo "$all_protocols" | grep -Fxq "$target_name"; then
+  echo "Error: Protocol '$target_name' not found in Immunefi programs list (ibb)." >&2
+  exit 1
+fi
+
+echo "Fetching the URLs of all assets in scope for $target_name"
+# Allow no matches without failing the script (grep exits 1 when no matches)
+urls=$(ibb "$target_name" assets url | grep -oP 'https://github\.com(?:/[^/]+){2}' | tr -d ',"' | sort | uniq || true)
+if [[ -z ${urls:-} ]]; then
+  urls=""
+fi
+# Count urls (unique, non-empty)
+url_count=0
+if [[ -n "$urls" ]]; then
+  url_count=$(printf '%s\n' "$urls" | sed '/^$/d' | wc -l | tr -d ' ')
+fi
+
+echo "Fetching BBP rewards for $target_name"
+# Ensure rewards is always an array (even if ibb returns empty/null)
+rewards=$(ibb "$target_name" rewards | jq 'map({severity, maxReward, minReward, fixedReward, payout, assetType, level}) // []')
+# Safely read first logo entry or empty string
+logo=$(ibb "$target_name" logo | jq -r '.[0] // ""')
+
+# Build protocol JSON object
+protocol_data=$(jq -n \
+  --arg name "$target_name" \
+  --arg logo "$logo" \
+  --argjson rewards "$rewards" \
+  --argjson urls "$( [[ -z $urls ]] && echo '[]' || printf '%s\n' "$urls" | uniq | jq -R . | jq -s . )" \
+  '{
+    protocol: $name,
+    logo: $logo,
+    rewards: $rewards,
+    assetUrls: $urls
+  }')
+
+tmp_file=$(mktemp)
+
+# Append new object to array
+jq --argjson item "$protocol_data" '. + [$item]' "$output_json" >"$tmp_file"
+mv "$tmp_file" "$output_json"
+
+echo "Protocol '$target_name' added to $output_json ($url_count repositories)"
+
+

--- a/backend-daf/target_protocols.json
+++ b/backend-daf/target_protocols.json
@@ -1,94 +1,94 @@
 [
-{
-  "protocol": "layerzero",
-  "logo": "https://images.ctfassets.net/t3wqy70tc3bv/3UXQcPOIAaOkE2QBCasSKa/14893bedf55bdb191e4cf99a67203e85/LayerZero_logo.jpeg",
-  "rewards": [
-    {
-      "severity": "critical",
-      "maxReward": 15000000,
-      "minReward": null,
-      "fixedReward": null,
-      "payout": null,
-      "assetType": "smart_contract",
-      "level": null
-    },
-    {
-      "severity": "high",
-      "maxReward": 250000,
-      "minReward": null,
-      "fixedReward": null,
-      "payout": null,
-      "assetType": "smart_contract",
-      "level": null
-    },
-    {
-      "severity": "medium",
-      "maxReward": 25000,
-      "minReward": null,
-      "fixedReward": null,
-      "payout": null,
-      "assetType": "smart_contract",
-      "level": null
-    },
-    {
-      "severity": "low",
-      "maxReward": 10000,
-      "minReward": null,
-      "fixedReward": null,
-      "payout": null,
-      "assetType": "smart_contract",
-      "level": null
-    }
-  ],
-  "assetUrls": [
-    "https://github.com/LayerZero-Labs/devtools",
-    "https://github.com/LayerZero-Labs/solidity-examples"
-  ]
-},
-{
-  "protocol": "reserve",
-  "logo": "https://images.ctfassets.net/t3wqy70tc3bv/2N1kPNfWAcD0jloxOqF4Cf/6e27b7ac7afb4180a3ade1e9d17bc4d5/reserve__1_.png",
-  "rewards": [
-    {
-      "severity": "critical",
-      "maxReward": 10000000,
-      "minReward": 100000,
-      "fixedReward": null,
-      "payout": null,
-      "assetType": "smart_contract",
-      "level": null
-    },
-    {
-      "severity": "high",
-      "maxReward": 100000,
-      "minReward": 10000,
-      "fixedReward": null,
-      "payout": null,
-      "assetType": "smart_contract",
-      "level": null
-    },
-    {
-      "severity": "medium",
-      "maxReward": null,
-      "minReward": null,
-      "fixedReward": 5000,
-      "payout": null,
-      "assetType": "smart_contract",
-      "level": null
-    },
-    {
-      "severity": "low",
-      "maxReward": null,
-      "minReward": null,
-      "fixedReward": 1000,
-      "payout": null,
-      "assetType": "smart_contract",
-      "level": null
-    }
-  ],
-  "assetUrls": [
-    "https://github.com/reserve-protocol/protocol",
-    "https://github.com/reserve-protocol/reserve-index-dtf"
-  ]
-}
+  {
+    "protocol": "layerzero",
+    "logo": "https://images.ctfassets.net/t3wqy70tc3bv/3UXQcPOIAaOkE2QBCasSKa/14893bedf55bdb191e4cf99a67203e85/LayerZero_logo.jpeg",
+    "rewards": [
+      {
+        "severity": "critical",
+        "maxReward": 15000000,
+        "minReward": null,
+        "fixedReward": null,
+        "payout": null,
+        "assetType": "smart_contract",
+        "level": null
+      },
+      {
+        "severity": "high",
+        "maxReward": 250000,
+        "minReward": null,
+        "fixedReward": null,
+        "payout": null,
+        "assetType": "smart_contract",
+        "level": null
+      },
+      {
+        "severity": "medium",
+        "maxReward": 25000,
+        "minReward": null,
+        "fixedReward": null,
+        "payout": null,
+        "assetType": "smart_contract",
+        "level": null
+      },
+      {
+        "severity": "low",
+        "maxReward": 10000,
+        "minReward": null,
+        "fixedReward": null,
+        "payout": null,
+        "assetType": "smart_contract",
+        "level": null
+      }
+    ],
+    "assetUrls": [
+      "https://github.com/LayerZero-Labs/devtools",
+      "https://github.com/LayerZero-Labs/solidity-examples"
+    ]
+  },
+  {
+    "protocol": "reserve",
+    "logo": "https://images.ctfassets.net/t3wqy70tc3bv/2N1kPNfWAcD0jloxOqF4Cf/6e27b7ac7afb4180a3ade1e9d17bc4d5/reserve__1_.png",
+    "rewards": [
+      {
+        "severity": "critical",
+        "maxReward": 10000000,
+        "minReward": 100000,
+        "fixedReward": null,
+        "payout": null,
+        "assetType": "smart_contract",
+        "level": null
+      },
+      {
+        "severity": "high",
+        "maxReward": 100000,
+        "minReward": 10000,
+        "fixedReward": null,
+        "payout": null,
+        "assetType": "smart_contract",
+        "level": null
+      },
+      {
+        "severity": "medium",
+        "maxReward": null,
+        "minReward": null,
+        "fixedReward": 5000,
+        "payout": null,
+        "assetType": "smart_contract",
+        "level": null
+      },
+      {
+        "severity": "low",
+        "maxReward": null,
+        "minReward": null,
+        "fixedReward": 1000,
+        "payout": null,
+        "assetType": "smart_contract",
+        "level": null
+      }
+    ],
+    "assetUrls": [
+      "https://github.com/reserve-protocol/protocol",
+      "https://github.com/reserve-protocol/reserve-index-dtf"
+    ]
+  }
 ]

--- a/backend-daf/targets.json
+++ b/backend-daf/targets.json
@@ -1,6 +1,0 @@
-{
-  "targets": [
-    "layerzero",
-    "reserve"
-  ]
-}


### PR DESCRIPTION
This change simplifies how users track specific Immunefi programs and improves clarity in our docs.

**What's included**
- New script: backend-daf/add-protocol-from-immunefi.sh
- Adds a single protocol by ID (as used by IBB)
- Fetches logo, rewards, and GitHub repositories in scope
- Appends to backend-daf/target_protocols.json (creates file if missing)
- Avoids duplicates and tolerates empty URLs/rewards/logo responses
- Prints the number of repositories included for visibility

**Docs: README.md**
- Updates the "Monitor target protocols" section to explain how it works now
- Reminds users they can manually add/remove repos in target_protocols.json

**Cleanup**
- Remove backend-daf/targets.json (no longer needed)

**Why**
- Reduces setup friction: a single command to add a target program
- Minimizes user error and repetitive work when editing JSON by hand
- Keeps target list flexible: users can still customize repos in target_protocols.json